### PR TITLE
Fix wordpress.conf

### DIFF
--- a/wordpress.conf
+++ b/wordpress.conf
@@ -8,8 +8,8 @@
 
   # Custom log file locations
   LogLevel warn
-  ErrorLog  /vagrant/log/error.log
-  CustomLog /vagrant/log/access.log combined
+  ErrorLog  "|/bin/cat > /vagrant/log/error.log"
+  CustomLog "|/bin/cat > /vagrant/log/access.log" combined
 
     <Directory />
       Options FollowSymLinks


### PR DESCRIPTION
apacheの起動とエラーログの作成タイミングが悪く、apacheが起動しない問題を修正
